### PR TITLE
Hopefully some fixes

### DIFF
--- a/Common/ModSystems/SeasonalEvents.cs
+++ b/Common/ModSystems/SeasonalEvents.cs
@@ -42,7 +42,7 @@ namespace Consolaria.Common {
 			=> ((currentDate.Day >= 20 && currentDate.Month == 1) || (currentDate.Day <= 15 && currentDate.Month == 2)) || allEventsForToday;
 
 		public static bool IsOktoberfest ()
-			=> ((currentDate.Day >= 27 && currentDate.Month == 9) || (currentDate.Day <= 31 && currentDate.Month == 10)) || allEventsForToday;
+			=> ((currentDate.Day >= 27 && currentDate.Month == 9) || (currentDate.Month == 10)) || allEventsForToday;
 
 		public static bool IsPatrickDay ()
 			=> (currentDate.Day >= 5 && currentDate.Month == 3) || allEventsForToday;

--- a/Common/ModSystems/SeasonalEvents.cs
+++ b/Common/ModSystems/SeasonalEvents.cs
@@ -33,22 +33,22 @@ namespace Consolaria.Common {
 		}
 
 		public static bool IsEaster ()
-			=> (currentDate.Day >= 1 && currentDate.Month == 4) || allEventsForToday;
+			=> currentDate.Month == 4 || allEventsForToday;
 
 		public static bool IsThanksgiving ()
-			=> (currentDate.Day >= 1 && currentDate.Month == 11) || allEventsForToday;
+			=> currentDate.Month == 11 || allEventsForToday;
 
 		public static bool IsChineseNewYear ()
-			=> ((currentDate.Day >= 20 && currentDate.Month == 1) && (currentDate.Day <= 15 && currentDate.Month == 2)) || allEventsForToday;
+			=> ((currentDate.Day >= 20 && currentDate.Month == 1) || (currentDate.Day <= 15 && currentDate.Month == 2)) || allEventsForToday;
 
 		public static bool IsOktoberfest ()
-			=> ((currentDate.Day >= 27 && currentDate.Month == 9) && (currentDate.Day <= 31 && currentDate.Month == 10)) || allEventsForToday;
+			=> ((currentDate.Day >= 27 && currentDate.Month == 9) || (currentDate.Day <= 31 && currentDate.Month == 10)) || allEventsForToday;
 
 		public static bool IsPatrickDay ()
-			=> ((currentDate.Day >= 5 && currentDate.Month == 3) && (currentDate.Day <= 31 && currentDate.Month == 3)) || allEventsForToday;
+			=> (currentDate.Day >= 5 && currentDate.Month == 3) || allEventsForToday;
 
 		public static bool IsValentineDay ()
-			=> ((currentDate.Day >= 1 && currentDate.Month == 2) && (currentDate.Day <= 29 && currentDate.Month == 2)) || allEventsForToday;
+			=> currentDate.Month == 2 || allEventsForToday;
 
 		public override void OnWorldLoad ()
 			=> allEventsForToday = false;

--- a/Content/NPCs/SpectralGastropod.cs
+++ b/Content/NPCs/SpectralGastropod.cs
@@ -12,7 +12,7 @@ using Terraria.ModLoader.Utilities;
 namespace Consolaria.Content.NPCs {
 	public class SpectralGastropod : ModNPC {
 		public override void SetStaticDefaults () {
-			DisplayName.SetDefault("Spectrapod");
+			DisplayName.SetDefault("Spectropod");
 			Main.npcFrameCount [NPC.type] = 11;
 
 			NPCDebuffImmunityData debuffData = new NPCDebuffImmunityData {


### PR DESCRIPTION
These things looked wrong to me while looking at the code. Basically:
* it doesn't seem useful to check that day >= 1 or <= 31, as those should trivially always be true (or <= 29 for February)
* when both dates checked are in the same month, it doesn't seem useful to check the month twice
* when both dates checked are not in the same month, the date cannot be expected to be in both months at once

The other thing I changed was a consistency fix for the spectral gastropod as the banner gave it a different name.

Now this was all done from within GitHub, I haven't set up my computer to compile Terraria mods, so this is not tested. Caveat emptor and all that. Feel free to use or discard.