### PR TITLE
Fix Boss HP scaling in multiplayer

### DIFF
--- a/Content/NPCs/Bosses/Lepus/Lepus.cs
+++ b/Content/NPCs/Bosses/Lepus/Lepus.cs
@@ -179,14 +179,8 @@ namespace Consolaria.Content.NPCs.Bosses.Lepus {
         }
 
         public override void ApplyDifficultyAndPlayerScaling (int numPlayers, float balance, float bossAdjustment) {
-            NPC.lifeMax = (int) (NPC.lifeMax * 0.5f * 1.25f);
-            NPC.damage = (int) (NPC.damage * 0.65f);
-            if (numPlayers <= 1) return;
-            float healthBoost = 0.35f;
-            for (int k = 1; k < numPlayers; k++) {
-                NPC.lifeMax += (int) (NPC.lifeMax * healthBoost);
-                healthBoost += (1 - healthBoost) / 3;
-            }
+            NPC.lifeMax = (int)((double)NPC.lifeMax * 0.5f * (double)balance * (double)bossAdjustment);
+            NPC.damage = (int)((double)NPC.damage * 0.65f);
         }
 
         public override void SetBestiary (BestiaryDatabase database, BestiaryEntry bestiaryEntry)

--- a/Content/NPCs/Bosses/Ocram/Ocram.cs
+++ b/Content/NPCs/Bosses/Ocram/Ocram.cs
@@ -124,14 +124,8 @@ namespace Consolaria.Content.NPCs.Bosses.Ocram
         }
 
         public override void ApplyDifficultyAndPlayerScaling (int numPlayers, float balance, float bossAdjustment) {
-            NPC.lifeMax = (int)(NPC.lifeMax * 0.5f * 1.3f);
-            NPC.damage = (int) (NPC.damage * 0.7f);
-            if (numPlayers <= 1) return;
-            float healthBoost = 0.35f;
-            for (int k = 1; k < numPlayers; k++) {
-                NPC.lifeMax += (int)(NPC.lifeMax * healthBoost);
-                healthBoost += (1 - healthBoost) / 3;
-            }
+            NPC.lifeMax = (int)((double)NPC.lifeMax * 0.5f * (double)balance * (double)bossAdjustment);
+            NPC.damage = (int)((double)NPC.damage * 0.7f);
         }
 
         public override void SetBestiary (BestiaryDatabase database, BestiaryEntry bestiaryEntry) {

--- a/Content/NPCs/Bosses/Turkor/TurkortheUngrateful.cs
+++ b/Content/NPCs/Bosses/Turkor/TurkortheUngrateful.cs
@@ -80,15 +80,9 @@ namespace Consolaria.Content.NPCs.Bosses.Turkor
 			if (!Main.dedServ) Music = ModContent.GetInstance<ConsolariaConfig>().vanillaBossMusicEnabled ? MusicID.Boss1 : MusicLoader.GetMusicSlot(Mod, "Assets/Music/Turkor");
 		}
 
-		public override void ApplyDifficultyAndPlayerScaling (int numPlayers, float balance, float bossAdjustment)/* tModPorter Note: bossLifeScale -> balance (bossAdjustment is different, see the docs for details) */ {
-			NPC.lifeMax = (int) (NPC.lifeMax * 0.5f * 1.4f);
-			NPC.damage = (int) (NPC.damage * 0.65f);
-			if (numPlayers <= 1) return;
-			float healthBoost = 0.35f;
-			for (int k = 1; k < numPlayers; k++) {
-				NPC.lifeMax += (int) (NPC.lifeMax * healthBoost);
-				healthBoost += (1 - healthBoost) / 3;
-			}
+		public override void ApplyDifficultyAndPlayerScaling (int numPlayers, float balance, float bossAdjustment) {
+            NPC.lifeMax = (int)((double)NPC.lifeMax * 0.5f * (double)balance * (double)bossAdjustment);
+            NPC.damage = (int)((double)NPC.damage * 0.65f);
 		}
 
 		public override void SetBestiary (BestiaryDatabase database, BestiaryEntry bestiaryEntry) {

--- a/Content/NPCs/Bosses/Turkor/TurkortheUngratefulHead.cs
+++ b/Content/NPCs/Bosses/Turkor/TurkortheUngratefulHead.cs
@@ -65,16 +65,9 @@ namespace Consolaria.Content.NPCs.Bosses.Turkor {
 			if (Main.masterMode) NPC.lifeMax = (int) (NPC.lifeMax * 0.798f);
 		}
 
-		public override void ApplyDifficultyAndPlayerScaling (int numPlayers, float balance, float bossAdjustment)/* tModPorter Note: bossLifeScale -> balance (bossAdjustment is different, see the docs for details) */
-		{
-			NPC.lifeMax = (int) (NPC.lifeMax * 0.5f * 1.7f);
-			NPC.damage = (int) (NPC.damage * 0.65f);
-			if (numPlayers <= 1) return;
-			float healthBoost = 0.35f;
-			for (int k = 1; k < numPlayers; k++) {
-				NPC.lifeMax += (int) (NPC.lifeMax * healthBoost);
-				healthBoost += (1 - healthBoost) / 3;
-			}
+		public override void ApplyDifficultyAndPlayerScaling (int numPlayers, float balance, float bossAdjustment) {
+			NPC.lifeMax = (int)((double)NPC.lifeMax * 0.5f * (double)balance * (double)bossAdjustment);
+			NPC.damage = (int)((double)NPC.damage * 0.65f);
 		}
 
 		private Rectangle GetFrame (int number)


### PR DESCRIPTION
In Multiplayer, all the bosses had very extreme HP scaling in Expert with just a few players. For example, with like 8 people online Lepus had over 1 million health.
This fixes that by fixing how we do ApplyDifficultyAndPlayerScaling